### PR TITLE
Use latest commit SHA to version Docker images

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -25,6 +25,9 @@ after_success:
   - sudo docker build -t nrgi/resourceprojects.org:$BRANCH.$COMMIT .
   # Create the `latest` tag
   - sudo docker tag -f nrgi/resourceprojects.org:$BRANCH.$COMMIT nrgi/resourceprojects.org:$BRANCH
+
+  - echo $BRANCH
+  - sudo docker images
   
   - sudo docker push nrgi/resourceprojects.org:$BRANCH
   - sudo docker push nrgi/resourceprojects.org:$BRANCH.$COMMIT

--- a/.shippable.yml
+++ b/.shippable.yml
@@ -8,6 +8,7 @@ branches:
     - staging
     - master
     - dev
+    - feature-203-version-images-with-commit-sha
 
 before_script:
   - npm install --dev

--- a/.shippable.yml
+++ b/.shippable.yml
@@ -24,7 +24,7 @@ script:
 after_success:
   - sudo docker build -t nrgi/resourceprojects.org:$BRANCH.$COMMIT .
   # Create the `latest` tag
-  - sudo docker tag nrgi/resourceprojects.org:$BRANCH.$COMMIT nrgi/resourceprojects.org:$BRANCH
+  - sudo docker tag -f nrgi/resourceprojects.org:$BRANCH.$COMMIT nrgi/resourceprojects.org:$BRANCH
   
   - sudo docker push nrgi/resourceprojects.org:$BRANCH
   - sudo docker push nrgi/resourceprojects.org:$BRANCH.$COMMIT

--- a/.shippable.yml
+++ b/.shippable.yml
@@ -8,7 +8,6 @@ branches:
     - staging
     - master
     - dev
-    - feature-203-version-images-with-commit-sha
 
 before_script:
   - npm install --dev

--- a/.shippable.yml
+++ b/.shippable.yml
@@ -24,9 +24,9 @@ script:
 
 after_success:
   - sudo docker build -t nrgi/resourceprojects.org:$BRANCH .
-  - sudo docker build -t nrgi/resourceprojects.org:$BRANCH.$BUILD_NUMBER .
+  - sudo docker build -t nrgi/resourceprojects.org:$BRANCH.$COMMIT .
   - sudo docker push nrgi/resourceprojects.org:$BRANCH
-  - sudo docker push nrgi/resourceprojects.org:$BRANCH.$BUILD_NUMBER
+  - sudo docker push nrgi/resourceprojects.org:$BRANCH.$COMMIT
 
 integrations:
     hub:

--- a/.shippable.yml
+++ b/.shippable.yml
@@ -23,12 +23,9 @@ script:
 
 after_success:
   - sudo docker build -t nrgi/resourceprojects.org:$BRANCH.$COMMIT .
-  # Create the `latest` tag
+  # Create the `latest` tag and force it in case the tag is already there from a previous build
   - sudo docker tag -f nrgi/resourceprojects.org:$BRANCH.$COMMIT nrgi/resourceprojects.org:$BRANCH
 
-  - echo $BRANCH
-  - sudo docker images
-  
   - sudo docker push nrgi/resourceprojects.org:$BRANCH
   - sudo docker push nrgi/resourceprojects.org:$BRANCH.$COMMIT
 

--- a/.shippable.yml
+++ b/.shippable.yml
@@ -23,8 +23,10 @@ script:
   - node_modules/karma/bin/karma start --browsers=PhantomJS --single-run --reporters coverage
 
 after_success:
-  - sudo docker build -t nrgi/resourceprojects.org:$BRANCH .
   - sudo docker build -t nrgi/resourceprojects.org:$BRANCH.$COMMIT .
+  # Create the `latest` tag
+  - sudo docker tag nrgi/resourceprojects.org:$BRANCH.$COMMIT nrgi/resourceprojects.org:$BRANCH
+  
   - sudo docker push nrgi/resourceprojects.org:$BRANCH
   - sudo docker push nrgi/resourceprojects.org:$BRANCH.$COMMIT
 


### PR DESCRIPTION
## Why
As a NRGI developer I want to be able to easily say which version of the code is deployed so that I know what features to expect to be available.

## What
- [ ] use the latest commit SHA to version images instead of the Shippable build number.

## Notes
The current tagging system (using Shippable build numbers) allows identifying the code version but in an indirect manner. We should tag using the commit SHA so we have a direct reference to the code being used.