### PR TITLE
API calls hang indefinitely causing 5XX erros

### DIFF
--- a/server/config/express.js
+++ b/server/config/express.js
@@ -71,12 +71,28 @@ module.exports = function(app, config, user, pass, env) {
                 sslCA: ca,
                 poolSize: 50,
                 socketOptions: {
+                    keepAlive: 120,
                     connectTimeoutMS: 10000,
-                    socketTimeoutMS: 15000
+                    socketTimeoutMS: 60000
                 }
             }
         };
         mongoose.connect('mongodb://' + user + ':' + pass + config.db, options);
+
+        mongoose.connection.on('connecting', function() {
+           console.log('Mongo connection connecting.');
+        });
+        mongoose.connection.on('connected', function() {
+            console.log('Mongo connection connected.');
+        });
+        mongoose.connection.on('close', function() {
+            console.log('Mongo connection closed.');
+        });
+        mongoose.connection.on('disconnected', function() {
+            console.log('Mongo connection disconnected.Triggering manual reconnect.');
+
+            mongoose.connect('mongodb://' + user + ':' + pass + config.db, options);
+        });
     }
     var db = mongoose.connection;
 


### PR DESCRIPTION
## Why
API calls should respond in a timely manner before the server or the loadbalancer cuts the connection.

What happens now is that API calls hang indefinetly after some time from server restart. They work when the node app is recently restarted but stop working after some time.

## What
- [x] prevent API calls from hanging indefinitely

## Notes
The app seems fine after being restarted, API calls are able to complete.

After stressing the server a bit, through loading pages or doing apache benchmark tests, the app starts to hang on doing DB queries. By hang it should be understood that the app does not return a response and neither logs an error.

With the use of console logs we've determined that the app hangs when doing DB queries. For example, in the snippet below, the app never gets to exec the callback even though it runs the LandingPage.find method:
```
exports.getLandingPage = function(req, res) {
    async.waterfall([
        getContent
    ], function (err, result) {
        if (err) {
            res.send(err);
        } else {
            if (req.query && req.query.callback) {
                return res.jsonp("" + req.query.callback + "(" + JSON.stringify(result) + ");");
            } else {
                return res.send(result);
            }
        }
    });
    function getContent(callback) {
        LandingPage.find({_id:'57639b9e2b50bbd70c2ff251'})
            .exec(function (err, content) {
                if(content.length>0){
                    callback(null, content[0])
                } else{
                    callback(null, content)
                }
            });
    }
};
```

After the app hangs for the first time then all subsequent API calls hang indefinitely. This can be tested with `curl`:
`curl http://localhost:3080/api/landing`